### PR TITLE
formatting of unary operators

### DIFF
--- a/src/main/java/com/javampire/openscad/formatter/OpenSCADFormattingModelBuilder.java
+++ b/src/main/java/com/javampire/openscad/formatter/OpenSCADFormattingModelBuilder.java
@@ -44,6 +44,11 @@ public class OpenSCADFormattingModelBuilder implements FormattingModelBuilder {
                 .after(IF_KEYWORD).spaceIf(settings.SPACE_BEFORE_IF_PARENTHESES)
                 .after(FOR_KEYWORD).spaceIf(settings.SPACE_BEFORE_FOR_PARENTHESES)
 
+                // Unary operators
+                .afterInside(PLUS, UNARY_PLUS_EXPR).spaceIf(settings.SPACE_AROUND_UNARY_OPERATOR)
+                .afterInside(MINUS, UNARY_MIN_EXPR).spaceIf(settings.SPACE_AROUND_UNARY_OPERATOR)
+                .afterInside(EXCL, UNARY_NEGATE_EXPR).spaceIf(settings.SPACE_AROUND_UNARY_OPERATOR)
+
                 // Around operators
                 .around(EQUALS).spaceIf(settings.SPACE_AROUND_ASSIGNMENT_OPERATORS)
                 .around(LOGICAL_OPERATORS).spaceIf(settings.SPACE_AROUND_LOGICAL_OPERATORS)

--- a/src/main/java/com/javampire/openscad/formatter/OpenSCADLanguageCodeStyleSettingsProvider.java
+++ b/src/main/java/com/javampire/openscad/formatter/OpenSCADLanguageCodeStyleSettingsProvider.java
@@ -40,7 +40,8 @@ public class OpenSCADLanguageCodeStyleSettingsProvider extends LanguageCodeStyle
                     "SPACE_AROUND_EQUALITY_OPERATORS",
                     "SPACE_AROUND_RELATIONAL_OPERATORS",
                     "SPACE_AROUND_ADDITIVE_OPERATORS",
-                    "SPACE_AROUND_MULTIPLICATIVE_OPERATORS"
+                    "SPACE_AROUND_MULTIPLICATIVE_OPERATORS",
+                    "SPACE_AROUND_UNARY_OPERATOR"
             );
             consumer.renameStandardOption("SPACE_AROUND_ASSIGNMENT_OPERATORS", "Assignment operator (=)");
 
@@ -68,6 +69,7 @@ public class OpenSCADLanguageCodeStyleSettingsProvider extends LanguageCodeStyle
                     "SPACE_WITHIN_FOR_PARENTHESES"
             );
             consumer.renameStandardOption("SPACE_WITHIN_FOR_PARENTHESES", "'for', 'intersect_for', 'assign', 'let' parentheses");
+            consumer.renameStandardOption("SPACE_AROUND_UNARY_OPERATOR", "Unary operators (!, -, +)");
 
             // Other
             consumer.showStandardOptions(
@@ -105,7 +107,7 @@ public class OpenSCADLanguageCodeStyleSettingsProvider extends LanguageCodeStyle
                 "\n" +
                 "function some_function(var1, var2 = \"string value\") = foo + sin(1.128e+10);\n" +
                 "\n" +
-                "if (x < max([1, 10]) || (x > 20 && x == 15)) {\n" +
+                "if (x < max([1, 10]) || !(x > -20 && x == 15)) {\n" +
                 "    some_module(x * 2, 42, \"string\");\n" +
                 "    \n" +
                 "} else if (x >= 42) {\n" +

--- a/src/test/testData/openscad/formatter/IndentObjectsElements.scad
+++ b/src/test/testData/openscad/formatter/IndentObjectsElements.scad
@@ -1,7 +1,7 @@
 render()
     color("red")
 rotate([0, 45, 0])
-                translate([20, 20, 20])
+                translate([-a-20, -20, 20])
                 cube([10, 10, 10]);
 
 translate([10, 10, 10]) {

--- a/src/test/testData/openscad/formatter/IndentObjectsElements_result_default.scad
+++ b/src/test/testData/openscad/formatter/IndentObjectsElements_result_default.scad
@@ -1,7 +1,7 @@
 render()
     color("red")
         rotate([0, 45, 0])
-            translate([20, 20, 20])
+            translate([-a - 20, -20, 20])
                 cube([10, 10, 10]);
 
 translate([10, 10, 10]) {

--- a/src/test/testData/openscad/formatter/IndentObjectsElements_result_noIndentCascadingTransformations.scad
+++ b/src/test/testData/openscad/formatter/IndentObjectsElements_result_noIndentCascadingTransformations.scad
@@ -1,7 +1,7 @@
 render()
 color("red")
 rotate([0, 45, 0])
-translate([20, 20, 20])
+translate([-a - 20, -20, 20])
 cube([10, 10, 10]);
 
 translate([10, 10, 10]) {


### PR DESCRIPTION
With this PR unary operator formatting follows Intellij standards with their own spacing option. Prior to this the + and - operator followed the spacing option for additive operators.