### PR TITLE
Support editor-fold tags for issue #108

### DIFF
--- a/src/main/java/com/javampire/openscad/editor/OpenSCADFoldingBuilder.java
+++ b/src/main/java/com/javampire/openscad/editor/OpenSCADFoldingBuilder.java
@@ -1,7 +1,7 @@
 package com.javampire.openscad.editor;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.lang.folding.FoldingBuilderEx;
+import com.intellij.lang.folding.CustomFoldingBuilder;
 import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
@@ -11,32 +11,32 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import com.javampire.openscad.psi.OpenSCADTypes;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static com.javampire.openscad.parser.OpenSCADParserTokenSets.IMPORT_FOLDING_TOKENS;
 import static com.javampire.openscad.parser.OpenSCADParserTokenSets.LINE_COMMENT_TOKENS;
 
-public class OpenSCADFoldingBuilder extends FoldingBuilderEx {
-    @NotNull
+public class OpenSCADFoldingBuilder extends CustomFoldingBuilder {
+
     @Override
-    public FoldingDescriptor[] buildFoldRegions(@NotNull PsiElement root, @NotNull Document document, boolean quick) {
-        List<FoldingDescriptor> descriptors = new ArrayList<>();
+    public void buildLanguageFoldRegions(@NotNull List<FoldingDescriptor> descriptors,
+                                         @NotNull PsiElement root,
+                                         @NotNull Document document,
+                                         boolean quick)
+    {
         addFoldsForElement(descriptors, root, document, quick);
-        return descriptors.toArray(new FoldingDescriptor[descriptors.size()]);
-    }
-
-    @Nullable
-    @Override
-    public String getPlaceholderText(@NotNull ASTNode node) {
-        return "...";
     }
 
     @Override
-    public boolean isCollapsedByDefault(@NotNull ASTNode node) {
+    public String getLanguagePlaceholderText(@NotNull ASTNode node, @NotNull TextRange range)
+    {
+        return "//...";
+    }
+
+    @Override
+    protected boolean isRegionCollapsedByDefault(@NotNull ASTNode node) {
         return false;
     }
 

--- a/src/main/resources/com/javampire/openscad/messages/OpenSCADBundle.properties
+++ b/src/main/resources/com/javampire/openscad/messages/OpenSCADBundle.properties
@@ -4,3 +4,5 @@ com.javampire.openscad.grouper.functions=Functions
 com.javampire.openscad.grouper.imports=Imports
 com.javampire.openscad.grouper.invalid=Invalid
 com.javampire.openscad.grouper.variables=Variables
+custom.folding.comments.vs.description=region...endregion Comments
+custom.folding.comments.net.beans.description=<editor-fold...> Comments


### PR DESCRIPTION
Add support for custom folding tags in two forms:

1. 

```
// <editor-fold desc="A description">
...
// </editor-fold>

```
2.
```
// region A description
...
// endregion

```