### PR TITLE
Fix resources not loading due to CORS errors in CEF browser

### DIFF
--- a/src/main/java/com/javampire/openscad/editor/OpenSCADPreviewFileEditor.java
+++ b/src/main/java/com/javampire/openscad/editor/OpenSCADPreviewFileEditor.java
@@ -18,6 +18,7 @@ import com.intellij.ui.jcef.JCEFHtmlPanel;
 import com.intellij.util.Alarm;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.javampire.openscad.action.*;
+import com.jetbrains.cef.JCefAppConfig;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
 import org.cef.browser.CefMessageRouter;
@@ -128,6 +129,14 @@ public class OpenSCADPreviewFileEditor extends UserDataHolderBase implements Fil
 
     private void attachHtmlPanel() {
         if (htmlPanel == null) {
+            var args = JCefAppConfig.getInstance().getAppArgsAsList();
+            if (!args.contains("--disable-web-security")) {
+                args.add("--disable-web-security");
+            }
+            if (!args.contains("--allow-file-access-from-files")) {
+                args.add("--allow-file-access-from-files");
+            }
+
             htmlPanel = new JCEFHtmlPanel(true, null, previewSite.htmlFile.getPreviewUrl().toExternalForm());
             final CefMessageRouter messageRouter = CefMessageRouter.create();
             messageRouter.addHandler(new CefMessageRouterHandler(), true);


### PR DESCRIPTION
Addresses the items described in issue https://github.com/ldenisey/idea-openscad/issues/117.

In recent releases of CEF (embedded Chromium) there is more strict CORS policy in place that impacts the browser's ability to load ES5+ modules and resources even using `file://` URIs.

As a temporary fix we can add CLI options  `--disable-web-security` and `--allow-file-access-from-files` to CEF to disable CORS policy for local file URIs.

Long term we would want to implement a minimal HTTP server to serve the resources (including rendered STLs) to the JS application inside CEF and keep the browser sandbox setting fully intact.